### PR TITLE
Update Vagrantfile for VmWare

### DIFF
--- a/ad/GOAD/providers/vmware/Vagrantfile
+++ b/ad/GOAD/providers/vmware/Vagrantfile
@@ -36,6 +36,12 @@ boxes = [
     # v.force_vmware_license = "workstation"  # force the licence for fix some vagrant plugin issue
   end
 
+   config.vm.provider "vmware_desktop" do |v|
+    v.vmx["memsize"] = "4000"
+    v.vmx["numvcpus"] = "2"
+    v.gui = true  # Enable GUI for VMware
+  end
+
   # disable rdp forwarded port inherited from StefanScherer box
   config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true, disabled: true
 
@@ -74,6 +80,8 @@ boxes = [
         target.vm.communicator = "winrm"
         target.vm.provision :shell, :path => "../../../../vagrant/Install-WMF3Hotfix.ps1", privileged: false
         target.vm.provision :shell, :path => "../../../../vagrant/ConfigureRemotingForAnsible.ps1", privileged: false
+        # Fix that pesky DNS issue and disable windows firewall before ansible esp for DC02
+	      target.vm.provision "shell", inline: "netsh advfirewall set allprofiles state off", privileged: true
 
         # fix ip for vmware
         if ENV['VAGRANT_DEFAULT_PROVIDER'] == "vmware_desktop"


### PR DESCRIPTION
Vmware fix: Add the VMs to the GUI instead of going to the vmware and importing the labs

Fix the DNS issue that might occur while deploying the lab esp on DC02